### PR TITLE
Documentation improvements and task fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Examples
 
 	- hosts: all
       roles:
-         - { role: threatstack, threatstack_deploy_key: XXXXXXXXXXXXX}
+         - { role: apollocatlin.threatstack, threatstack_deploy_key: XXXXXXXXXXXXX}
 
 2) Install Threat Stack agent with custom security policy and custom hostname:
 
     - hosts: servers
       roles:
-    	- role: threatstack
+    	- role: apollocatlin.threatstack
       	  threatstack_deploy_key: XXXXXXXXXXXXX
       	  threatstack_policy: "My Secure Policy"
       	  threatstack_hostname: SparkServer1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,6 @@
 # defaults file for threatstack
 
 threatstack_pkg_url: 'https://pkg.threatstack.com/'
+threatstack_hostname:
+threatstack_policy:
+

--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -29,10 +29,6 @@
   args:
     creates: /opt/threatstack/cloudsight/config/.secret
 
-- name: fail the play if the previous command did not succeed
-  fail: msg="Cloudsight Install Failed"
-  when: "'FAILED' in setup_result.stderr"
-
 # Test
 - name: Test cloudsight state
   service:


### PR DESCRIPTION
The commit to remove the check for failed setup is required if we're not setting both the hostname and policy as the registered variable will be for the last (skipped) task and won't contain stderr.

The play will fail anyway since we're not ignoring errors, so non-zero result codes will result in the task failing.

If we really want to display a more friendly message, two solutions that come to mind are:

1. Use different variables and check if each was skipped, and if not, what the result code or output was.
2. Use one command with inline conditionals to include the appropriate options

In both cases, you'll want to add "ignore_errors: true" to the task(s).