### PR TITLE
add threatstack_configure_agent option

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,8 @@ provisioner:
   ansible_verbose: true
   playbook: tests/test.yml
   hosts: localhost
+  extra_vars:
+    threatstack_deploy_key: <%= ENV['TS_DEPLOY_KEY'] != nil ? ENV['TS_DEPLOY_KEY'] : 'ts_deploy_key' %>
 
 platforms:
   - name: ubuntu-12.04

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ threatstack_hostname:
 threatstack_ruleset:
 threatstack_config_dir: '/etc/threatstack'
 threatstack_config: "{{ threatstack_config_dir }}/tsconfig.json"
+threatstack_configure_agent: true

--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -15,7 +15,6 @@
 - name: Cloudsight - setup default
   command: cloudsight setup --config="{{ threatstack_config }}"
   register: setup_result
-  failed_when: setup_result.stderr and 'FAILED' in setup_result.stderr
   args:
     creates: /opt/threatstack/cloudsight/config/.secret
 

--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -16,7 +16,7 @@
   command: cloudsight setup --config="{{ threatstack_config }}"
   register: setup_result
   args:
-    creates: /opt/threatstack/cloudsight/config/.secret
+    creates: /opt/threatstack/cloudsight/config/.audit
 
 # Test
 - name: Test cloudsight state

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,4 @@
 
 - name: Fire cloudsight setup
   include: cloudsight_setup.yml
+  when: threatstack_configure_agent == true


### PR DESCRIPTION
Useful for installing the package into a base image where activation
will not be done until host deploy.
