### PR TITLE
Pass threatstack_feature_plan to agent configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,8 @@ threatstack_pkg_url: 'https://pkg.threatstack.com'
 threatstack_pkg_state: installed
 # to set a version of the agent use threatstack-agent=X.Y.Z
 threatstack_pkg:  threatstack-agent
-threatstack_hostname:
-threatstack_ruleset:
+#threatstack_hostname:
+#threatstack_ruleset:
 threatstack_config_dir: '/etc/threatstack'
 threatstack_config: "{{ threatstack_config_dir }}/tsconfig.json"
 threatstack_configure_agent: true
@@ -16,4 +16,4 @@ threatstack_agent_config_args:
 # Set according to feature plan. https://www.threatstack.com/plans
 # * agent_type="i" - Investigate, Legacy (Basic, Pro, Advanced)
 # * agent_type="m" - Monitor
-threatstack_feature_plan:
+agent_type: "{{ threatstack_feature_plan | mandatory }}"

--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -2,7 +2,13 @@
 
 # Cloudsight Setup
 - name: Create Threat Stack Config Directory
-  file: path="{{ threatstack_config_dir }}" state=directory owner=root group=root mode=0644 recurse=yes
+  file:
+    path: "{{ threatstack_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+    recurse: yes
 
 - name: Create ThreatStack Config File
   template:
@@ -13,25 +19,25 @@
     mode: 0644
 
 - name: Cloudsight - setup default
-  command: cloudsight setup --config="{{ threatstack_config }}" {{ threatstack_agent_extra_args }}
+  command: cloudsight setup --config={{ threatstack_config }} --agent_type={{ agent_type }} {{ threatstack_agent_extra_args }}
   register: setup_result
   args:
     creates: /opt/threatstack/cloudsight/config/.audit
 
 - name: Create file to track extra Cloudsight config
   copy:
-    content: "{{ threatstack_agent_config_args }} {{threatstack_feature_plan}}"
+    content: "{{ threatstack_agent_config_args }} {{ agent_type }}"
     dest: /opt/threatstack/cloudsight/config/.config_args
     owner: root
     group: root
     mode: 0644
   when:
-    - threatstack_agent_config_args|default(None) != None
-    - threatstack_feature_plan|default(None) != None
+    - threatstack_agent_config_args is undefined
+    - agent_type is undefined
   register: config_args
 
 - name: Configure extra cloudsight parameters
-  command: "cloudsight config {{ threatstack_agent_config_args }} {{threatstack_feature_plan}}"
+  command: "cloudsight config {{ threatstack_agent_config_args }} {{ agent_type }}"
   when: config_args.changed
   notify: restart cloudsight
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
 # Setup tasks
-
-- name: threatstack_package_plan is unset
-  debug: msg="Must set threatstack_package_plan; this will soon become a failure."
-  when: threatstack_feature_plan|default(None) == None
-
 - name: Run Apt configure and install Threat Stack
   include: apt_install.yml
   when: ansible_os_family == 'Debian'

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,9 +1,9 @@
 {
-{% if threatstack_hostname %}
+{% if threatstack_hostname is defined %}
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
-{% if threatstack_ruleset %}
+{% if threatstack_ruleset is defined %}
   "ruleset": "{{ threatstack_ruleset }}",
 {% endif %}
-  "deploy-key": "{{ threatstack_deploy_key }}"
+  "deploy-key": "{{ threatstack_deploy_key | mandatory }}"
 }

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,6 +8,7 @@
     threatstack_hostname: 'TravisCI_{{timestamp}}'
     threatstack_config_dir: '/etc/threatstack'
     threatstack_config: "{{ threatstack_config_dir }}/tsconfig.json"
+    threatstack_feature_plan: i
     test_output: false
   roles:
     - threatstack-ansible


### PR DESCRIPTION
This will enable `threatstack_feature_plan` to set the config to `m` or `i` depending on the Threat Stack plan of the customer. It also requires that this variable is set to install the agent.