### PR TITLE
Don't add the Debian Stretch repo

### DIFF
--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -20,6 +20,7 @@
     repo: "deb {{ threatstack_pkg_url }}/Ubuntu {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
+  when: ansible_distribution_release != 'stretch'
 
 - name: Ensure Threat Stack is installed.
   apt:


### PR DESCRIPTION
Why:

* It breaks `apt-get update`