### PR TITLE
Support threatstack_ruleset array of values

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ provisioner:
     threatstack_pkg: <%= ENV['TS_PACKAGE_VERSION'] %>
     <% end %>
     <% if ENV['TS_RULE_SETS'] %>
-    threatstack_ruleset: "<%= ENV['TS_RULE_SETS'] != nil ? ENV['TS_RULE_SETS'] : 'Base Rule Set' %>"
+    threatstack_ruleset: "<%= ENV['TS_RULE_SETS'] %>"
     <% end %>
 
 platforms:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,8 @@ threatstack_pkg_state: installed
 # to set a version of the agent use threatstack-agent=X.Y.Z
 threatstack_pkg:  threatstack-agent
 #threatstack_hostname:
-#threatstack_ruleset:
+threatstack_ruleset:
+  - 'Base Rule Set'
 threatstack_config_dir: '/etc/threatstack'
 threatstack_config: "{{ threatstack_config_dir }}/tsconfig.json"
 threatstack_configure_agent: true

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -3,7 +3,7 @@
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
 {% if threatstack_ruleset | length > 0 %}
-  "ruleset": "{{ threatstack_ruleset | join(",") }}"
+  "ruleset": "{{ threatstack_ruleset | join(",") }}",
 {% endif %}
   "deploy-key": "{{ threatstack_deploy_key | mandatory }}"
 }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -2,8 +2,8 @@
 {% if threatstack_hostname is defined %}
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
-{% if threatstack_ruleset is defined %}
-  "ruleset": "{{ threatstack_ruleset }}",
+{% if threatstack_ruleset.len() > 0 %}
+  "ruleset": "{{ threatstack_ruleset.join(",") }}"
 {% endif %}
   "deploy-key": "{{ threatstack_deploy_key | mandatory }}"
 }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -2,7 +2,7 @@
 {% if threatstack_hostname is defined %}
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
-{% if len(threatstack_ruleset) > 0 %}
+{% if threatstack_ruleset | length > 0 %}
   "ruleset": "{{ threatstack_ruleset.join(",") }}"
 {% endif %}
   "deploy-key": "{{ threatstack_deploy_key | mandatory }}"

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -3,7 +3,7 @@
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
 {% if threatstack_ruleset | length > 0 %}
-  "ruleset": "{{ threatstack_ruleset.join(",") }}"
+  "ruleset": "{{ threatstack_ruleset | join(",") }}"
 {% endif %}
   "deploy-key": "{{ threatstack_deploy_key | mandatory }}"
 }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -2,7 +2,7 @@
 {% if threatstack_hostname is defined %}
   "hostname": "{{ threatstack_hostname }}",
 {% endif %}
-{% if threatstack_ruleset.len() > 0 %}
+{% if len(threatstack_ruleset) > 0 %}
   "ruleset": "{{ threatstack_ruleset.join(",") }}"
 {% endif %}
   "deploy-key": "{{ threatstack_deploy_key | mandatory }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,8 @@
   vars:
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d') }}"
     threatstack_deploy_key: "{{ lookup('env','API_KEY') }}"
-    threatstack_ruleset: 'Travis Rule Set'
+    threatstack_ruleset:
+      - 'Travis Rule Set'
     threatstack_hostname: 'TravisCI_{{timestamp}}'
     threatstack_config_dir: '/etc/threatstack'
     threatstack_config: "{{ threatstack_config_dir }}/tsconfig.json"


### PR DESCRIPTION
Change type of `threatstack_ruleset` value to an array of strings to support multiple ruleset specification in ansible.