### PR TITLE
Update apt state value to squelch deprecation warnings in Ansible 2.7

### DIFF
--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -2,12 +2,12 @@
 - name: python-apt dependency.
   apt:
     name: python-apt
-    state: installed
+    state: present
 
 - name: apt-transport-https dependency.
   apt:
     name: apt-transport-https
-    state: installed
+    state: present
 
 - name: Add Threat Stack apt repository key.
   apt_key:


### PR DESCRIPTION
fixes #39 