### PR TITLE
Update install script for agent version 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python: '2.7'
 sudo: required

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Role Variables
 The following variables are available for override.
 ```
 threatstack_deploy_key:         # Required. Your Cloud Sight API Key
-threatstack_feature_plan:       # REQUIRED FOR VERSIONS 1.x ONLY
-                                # Set value to reflect your feature plan. https://www.threatstack.com/plans
-                                # * 'agent_type="i"' - Investigate or Legacy (Basic, Advanced, Pro)
-                                # * 'agent_type="m"' - Monitor
+threatstack_feature_plan:       # AGENT 1.x ONLY!
+                                #   Required. Set value to reflect your feature plan. https://www.threatstack.com/plans
+                                #   * 'agent_type="i"' - Investigate or Legacy (Basic, Advanced, Pro)
+                                #   * 'agent_type="m"' - Monitor
 threatstack_ruleset:            # Array of agent rule sets, will default to ["Base Rule Set"].
                                 # Define multiple rule sets using a comma seperated list.
 threatstack_pkg_url:            # Location of package repo. Only change if you mirror your own.
@@ -37,7 +37,9 @@ threatstack_pkg:                # Name of package. Specify package version using
 threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
 threatstack_hostname:           # The display hostname in the Threat Stack UI. Defaults to hostname.
 threatstack_configure_agent:    # Optionally do not configure the host, just install package
-threatstack_agent_config_args:  # Pass optional configuration arguments during agent registration.
+threatstack_agent_extra_args:   # Pass optional configuration arguments during agent registration.
+threatstack_agent_config_args:  # AGENT 1.x ONLY!
+                                #   Pass optional configuration arguments after agent registration.
 ```
 
 Install

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ threatstack_deploy_key:         # Required. Your Cloud Sight API Key
 threatstack_feature_plan:       # Set value to reflect your feature plan. https://www.threatstack.com/plans
                                 # * 'agent_type="i"' - Investigate or Legacy (Basic, Advanced, Pro)
                                 # * 'agent_type="m"' - Monitor
-threatstack_ruleset:            # The Agent's rule set, will default to "Default Rule Set".
+threatstack_ruleset:            # The Agent's rule set, will default to "Base Rule Set".
                                 # Define multiple rule sets using a comma seperated list.
 threatstack_pkg_url:            # Location of package repo. Only change if you mirror your own.
 threatstack_pkg:                # name of package. Specify package version using "threatstack-agent=X.Y.Z"
-threatstack_hostname:           # The display hostname in the Threat Stack UI
+threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
 threatstack_configure_agent:    # Optionally do not configure the host, just install package
 threatstack_agent_config_args:  # Pass optional configuration arguments during agent registration.
 ```

--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ threatstack_pkg:                # Name of package. Specify package version using
 threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
 threatstack_hostname:           # The display hostname in the Threat Stack UI. Defaults to hostname.
 threatstack_configure_agent:    # Optionally do not configure the host, just install package
-threatstack_agent_extra_args:   # Pass optional configuration arguments during agent registration.
-threatstack_agent_config_args:  # AGENT 1.x ONLY!
-                                #   Pass optional configuration arguments after agent registration.
+threatstack_agent_extra_args:   # Pass optional arguments during agent registration.
+threatstack_agent_config_args:  # Pass optional configuration arguments after agent registration.
 ```
 
 Install

--- a/README.md
+++ b/README.md
@@ -16,19 +16,24 @@ Platforms
 * CentOS
 * RedHat
 * Ubuntu
+* Debian
 
 Role Variables
 --------------
 The following variables are available for override.
 ```
 threatstack_deploy_key:         # Required. Your Cloud Sight API Key
-threatstack_feature_plan:       # Set value to reflect your feature plan. https://www.threatstack.com/plans
+threatstack_feature_plan:       # REQUIRED FOR VERSIONS 1.x ONLY
+                                # Set value to reflect your feature plan. https://www.threatstack.com/plans
                                 # * 'agent_type="i"' - Investigate or Legacy (Basic, Advanced, Pro)
                                 # * 'agent_type="m"' - Monitor
 threatstack_ruleset:            # Array of agent rule sets, will default to ["Base Rule Set"].
                                 # Define multiple rule sets using a comma seperated list.
 threatstack_pkg_url:            # Location of package repo. Only change if you mirror your own.
-threatstack_pkg:                # name of package. Specify package version using "threatstack-agent=X.Y.Z" (Debian) or "threatstack-agent-X.Y.Z" (RedHat)
+threatstack_pkg:                # Name of package. Specify package version using
+                                #  "threatstack-agent=X.Y.Z" (Debian/Ubuntu)
+                                #  "threatstack-agent-X.Y.Z" (RedHat/CentOS/Amazon)
+                                # Defaults to latest available version.
 threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
 threatstack_hostname:           # The display hostname in the Threat Stack UI. Defaults to hostname.
 threatstack_configure_agent:    # Optionally do not configure the host, just install package

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ threatstack_deploy_key:         # Required. Your Cloud Sight API Key
 threatstack_feature_plan:       # Set value to reflect your feature plan. https://www.threatstack.com/plans
                                 # * 'agent_type="i"' - Investigate or Legacy (Basic, Advanced, Pro)
                                 # * 'agent_type="m"' - Monitor
-threatstack_ruleset:            # The Agent's rule set, will default to "Base Rule Set".
+threatstack_ruleset:            # Array of agent rule sets, will default to ["Base Rule Set"].
                                 # Define multiple rule sets using a comma seperated list.
 threatstack_pkg_url:            # Location of package repo. Only change if you mirror your own.
 threatstack_pkg:                # name of package. Specify package version using "threatstack-agent=X.Y.Z" (Debian) or "threatstack-agent-X.Y.Z" (RedHat)
 threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
+threatstack_hostname:           # The display hostname in the Threat Stack UI. Defaults to hostname.
 threatstack_configure_agent:    # Optionally do not configure the host, just install package
 threatstack_agent_config_args:  # Pass optional configuration arguments during agent registration.
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ threatstack_feature_plan:       # Set value to reflect your feature plan. https:
 threatstack_ruleset:            # The Agent's rule set, will default to "Base Rule Set".
                                 # Define multiple rule sets using a comma seperated list.
 threatstack_pkg_url:            # Location of package repo. Only change if you mirror your own.
-threatstack_pkg:                # name of package. Specify package version using "threatstack-agent=X.Y.Z"
+threatstack_pkg:                # name of package. Specify package version using "threatstack-agent=X.Y.Z" (Debian) or "threatstack-agent-X.Y.Z" (RedHat)
 threatstack_url:                # The URL of the Threat Stack webapp. Defaults to https://app.threatstack.com
 threatstack_configure_agent:    # Optionally do not configure the host, just install package
 threatstack_agent_config_args:  # Pass optional configuration arguments during agent registration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # defaults file for threatstack
 
-threatstack_pkg_url: 'https://pkg.threatstack.com'
+threatstack_v1_pkg_url: 'https://pkg.threatstack.com'
+threatstack_v2_pkg_url: 'https://pkg.threatstack.com/v2'
 threatstack_pkg_state: installed
 # to set a version of the agent use threatstack-agent=X.Y.Z
 threatstack_pkg:  threatstack-agent

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ threatstack_pkg_url: 'https://pkg.threatstack.com'
 threatstack_pkg_state: installed
 # to set a version of the agent use threatstack-agent=X.Y.Z
 threatstack_pkg:  threatstack-agent
-#threatstack_hostname:
+threatstack_url: https://app.threatstack.com
 threatstack_ruleset:
   - 'Base Rule Set'
 threatstack_config_dir: '/etc/threatstack'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 threatstack_v1_pkg_url: 'https://pkg.threatstack.com'
 threatstack_v2_pkg_url: 'https://pkg.threatstack.com/v2'
 threatstack_pkg_state: installed
-# to set a version of the agent use threatstack-agent=X.Y.Z
+# to set a version of the agent use threatstack-agent=X.Y.Z (Debian) or threatstack-agent-X.Y.Z (RedHat)
 threatstack_pkg:  threatstack-agent
 threatstack_url: https://app.threatstack.com
 threatstack_ruleset:
@@ -18,4 +18,4 @@ threatstack_agent_config_args:
 # Set according to feature plan. https://www.threatstack.com/plans
 # * agent_type="i" - Investigate, Legacy (Basic, Pro, Advanced)
 # * agent_type="m" - Monitor
-agent_type: "{{ threatstack_feature_plan | mandatory }}"
+agent_type: "{{ threatstack_feature_plan | default('') }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,5 @@
 - name: restart cloudsight
   service: name=cloudsight state=restarted
+
+- name: restart tsagent
+  service: name=threatstack state=restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,32 +4,29 @@ galaxy_info:
   description: Ansible role to install the threatstack agent
   company: Threat Stack
   license: license (Apache)
-  min_ansible_version: 1.3
+  min_ansible_version: 1.6
   platforms:
   - name: EL
     versions:
     - all
-    - 6
     - 7
   - name: Debian
     versions:
     - all
-    - 7
     - 8
-  - name: Fedora
-    versions:
-    - 25
+    - 9
   - name: Amazon
     versions:
     - all
-    - 2013.03
-    - 2013.09
+    - 2017.09
+    - 2018.03
+    - 2
   - name: Ubuntu
     versions:
     - all
-    - precise
     - trusty
     - xenial
+    - bionic
   categories:
   - cloud
   - cloud:ec2

--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -1,6 +1,7 @@
 ---
 
-# Cloudsight Setup
+# 1.x agent setup
+
 - name: Create Threat Stack Config Directory
   file:
     path: "{{ threatstack_config_dir }}"
@@ -18,8 +19,8 @@
     group: root
     mode: 0644
 
-- name: Cloudsight - setup default
-  command: cloudsight setup --config={{ threatstack_config }} --agent_type={{ agent_type }} {{ threatstack_agent_extra_args }}
+- name: Agent setup
+  command: cloudsight setup --url={{ threatstack_url }} --config={{ threatstack_config }} --agent_type={{ agent_type }} {{ threatstack_agent_extra_args }}
   register: setup_result
   args:
     creates: /opt/threatstack/cloudsight/config/.audit
@@ -41,7 +42,7 @@
   when: config_args.changed
   notify: restart cloudsight
 
-- name: Test cloudsight state
+- name: Test agent state
   service:
     name: cloudsight
     enabled: yes

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,0 +1,15 @@
+---
+- name: Check if agent is v1.x
+  set_fact:
+    threatstack_v1_string: "{{ threatstack_pkg | regex_search('agent[=-]1\\.') }}"
+
+- name: Define v1 variable
+  set_fact:
+    threatstack_v1: "{{ threatstack_v1_string != '' }}"
+
+- name: Ensure agent_type is defined
+  fail:
+    msg: "threatstack_feature_plan is mandatory for 1.x agents!"
+  when:
+    - threatstack_v1
+    - agent_type == ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
-# Setup tasks
+- name: Define some facts based on variables
+  include: facts.yml
+
+- name: Ensure package URL is defined
+  include: pkg_url.yml
+  when: threatstack_pkg_url is undefined
+
 - name: Run Apt configure and install Threat Stack
   include: apt_install.yml
   when: ansible_os_family == 'Debian'
@@ -12,10 +18,10 @@
   include: cloudsight_setup.yml
   when:
     - threatstack_configure_agent == true
-    - not threatstack_v2
+    - threatstack_v1
 
 - name: 2.x agent setup
   include: tsagent_setup.yml
   when:
     - threatstack_configure_agent == true
-    - threatstack_v2
+    - not threatstack_v1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,10 @@
   include: cloudsight_setup.yml
   when:
     - threatstack_configure_agent == true
-    - threatstack_pkg | regex_search('agent[=-]1.')
+    - not threatstack_v2
 
 - name: 2.x agent setup
   include: tsagent_setup.yml
   when:
     - threatstack_configure_agent == true
-    - threatstack_pkg | regex_search('agent[=-]2.')
+    - threatstack_v2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
   include: yum_install.yml
   when: ansible_os_family == 'RedHat'
 
-- name: Fire cloudsight setup
+- name: 1.x agent setup
   include: cloudsight_setup.yml
-  when: threatstack_configure_agent == true
+  when:
+    - threatstack_configure_agent == true
+    - threatstack_pkg is search("=1.")
+
+- name: 2.x agent setup
+  include: tsagent_setup.yml
+  when:
+    - threatstack_configure_agent == true
+    - threatstack_pkg is search("=2.")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,10 @@
   include: cloudsight_setup.yml
   when:
     - threatstack_configure_agent == true
-    - threatstack_pkg is search("=1.")
+    - threatstack_pkg | regex_search('agent[=-]1.')
 
 - name: 2.x agent setup
   include: tsagent_setup.yml
   when:
     - threatstack_configure_agent == true
-    - threatstack_pkg is search("=2.")
+    - threatstack_pkg | regex_search('agent[=-]2.')

--- a/tasks/pkg_url.yml
+++ b/tasks/pkg_url.yml
@@ -1,14 +1,10 @@
 ---
-- name: Define v2 variable
-  set_fact:
-    threatstack_v2: threatstack_pkg | regex_search('agent[=-]2.')
-
 - name: Define v1 package URL variable
   set_fact:
     threatstack_pkg_url: "{{ threatstack_v1_pkg_url }}"
-  when: not threatstack_v2
+  when: threatstack_v1
 
 - name: Define v2 package URL variable
   set_fact:
     threatstack_pkg_url: "{{ threatstack_v2_pkg_url }}"
-  when: threatstack_v2
+  when: not threatstack_v1

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -1,0 +1,18 @@
+---
+
+# 2.x agent setup
+
+- name: Agent setup
+  command: tsagent setup -url {{ threatstack_url }} -deploy-key {{ threatstack_deploy_key }} -ruleset {{ threatstack_ruleset }} {{ threatstack_agent_extra_args }}
+  register: setup_result
+
+- name: Configure extra agent parameters
+  command: "tsagent config --set {{ threatstack_agent_config_args }}"
+  when: config_args.changed
+  notify: restart tsagent
+
+- name: Test agent state
+  service:
+    name: threatstack
+    enabled: yes
+    state: started

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -2,17 +2,39 @@
 
 # 2.x agent setup
 
-- name: Agent setup
-  command: tsagent setup -url {{ threatstack_url }} -deploy-key {{ threatstack_deploy_key }} -ruleset "{{ threatstack_ruleset | join(",") }}" {{ threatstack_agent_extra_args }}
-  register: setup_result
+- name: Get setup string
+  set_fact:
+    setup_string: tsagent setup -url {{ threatstack_url }} -deploy-key {{ threatstack_deploy_key }} -ruleset "{{ threatstack_ruleset | join(",") }}" {{ threatstack_agent_extra_args }}
 
-- name: Configure extra agent parameters
-  command: "tsagent config --set {{ threatstack_agent_config_args }}"
-  when: config_args.changed
-  notify: restart tsagent
+- name: Get checksum of setup string
+  set_fact:
+    setup_checksum: "{{ setup_string | checksum }}"
+
+- name: Create file to track checksum of setup string
+  copy:
+    content: "{{ setup_checksum }}"
+    dest: /opt/threatstack/etc/.setup_checksum
+    owner: root
+    group: root
+    mode: 0644
+  register: setup_file
+
+- name: Agent setup
+  command: "{{ setup_string }}"
+  register: setup_result
+  changed_when: False
+
+- name: Restart tsagent
+  service: name=threatstack state=restarted
+  when: setup_file.changed
 
 - name: Test agent state
-  service:
-    name: threatstack
-    enabled: yes
-    state: started
+  command: tsagent status
+  register: tsagent_status
+  retries: 5
+  delay: 2
+  until: tsagent_status.rc == 0
+  when: setup_file.changed
+
+- name: Ensure agent is running
+  service: name=threatstack state=started

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -3,7 +3,7 @@
 # 2.x agent setup
 
 - name: Agent setup
-  command: tsagent setup -url {{ threatstack_url }} -deploy-key {{ threatstack_deploy_key }} -ruleset {{ threatstack_ruleset }} {{ threatstack_agent_extra_args }}
+  command: tsagent setup -url {{ threatstack_url }} -deploy-key {{ threatstack_deploy_key }} -ruleset "{{ threatstack_ruleset | join(",") }}" {{ threatstack_agent_extra_args }}
   register: setup_result
 
 - name: Configure extra agent parameters

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -19,14 +19,39 @@
     mode: 0644
   register: setup_file
 
+- name: Get config string
+  set_fact:
+    config_string: tsagent config -set {{ threatstack_agent_config_args }}
+
+- name: Get checksum of config string
+  set_fact:
+    config_checksum: "{{ config_string | checksum }}"
+
+- debug:
+    msg: "{{ threatstack_agent_config_args }}"
+
+- name: Create file to track checksum of config string
+  copy:
+    content: "{{ config_checksum }}"
+    dest: /opt/threatstack/etc/.config_checksum
+    owner: root
+    group: root
+    mode: 0644
+  register: config_file
+  when: threatstack_agent_config_args != None
+
 - name: Agent setup
   command: "{{ setup_string }}"
   register: setup_result
   changed_when: False
 
+- name: Agent config
+  command: "{{ config_string }}"
+  when: config_file.changed
+
 - name: Restart tsagent
   service: name=threatstack state=restarted
-  when: setup_file.changed
+  when: setup_file.changed or config_file.changed
 
 - name: Test agent state
   command: tsagent status
@@ -34,7 +59,7 @@
   retries: 5
   delay: 2
   until: tsagent_status.rc == 0
-  when: setup_file.changed
+  when: setup_file.changed or config_file.changed
 
 - name: Ensure agent is running
   service: name=threatstack state=started

--- a/tasks/version_facts.yaml
+++ b/tasks/version_facts.yaml
@@ -1,0 +1,14 @@
+---
+- name: Define v2 variable
+  set_fact:
+    threatstack_v2: threatstack_pkg | regex_search('agent[=-]2.')
+
+- name: Define v1 package URL variable
+  set_fact:
+    threatstack_pkg_url: "{{ threatstack_v1_pkg_url }}"
+  when: not threatstack_v2
+
+- name: Define v2 package URL variable
+  set_fact:
+    threatstack_pkg_url: "{{ threatstack_v2_pkg_url }}"
+  when: threatstack_v2

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,4 +1,7 @@
 {
+{% if threatstack_hostname is defined %}
+  "hostname": "{{ threatstack_hostname }}",
+{% endif %}
 {% if threatstack_url is defined %}
   "url": "{{ threatstack_url }}",
 {% endif %}

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,6 +1,6 @@
 {
-{% if threatstack_hostname is defined %}
-  "hostname": "{{ threatstack_hostname }}",
+{% if threatstack_url is defined %}
+  "url": "{{ threatstack_url }}",
 {% endif %}
 {% if threatstack_ruleset | length > 0 %}
   "ruleset": "{{ threatstack_ruleset | join(",") }}",

--- a/templates/threatstack.j2
+++ b/templates/threatstack.j2
@@ -1,7 +1,13 @@
 [threatstack]
 name=Threat Stack Package Repository
 {% if ansible_distribution == 'Amazon' %}
+{% if threatstack_v1 %}
 baseurl={{threatstack_pkg_url}}/Amazon
+{% elif ansible_distribution_version == '2' %}
+baseurl={{threatstack_pkg_url}}/Amazon/2
+{% else %}
+baseurl={{threatstack_pkg_url}}/Amazon/1
+{% endif %}
 {% elif ansible_distribution == 'CentOS' %}
 baseurl={{threatstack_pkg_url}}/EL/{{ansible_distribution_major_version}}
 {% else %}


### PR DESCRIPTION
Changes:
- Updated agent setup/configure syntax to work for agent 2.x
- Added `threatstack_url` to allow for internal testing on non-prod environments
- Using different repo for 2.x

Tested on:

- amzn-201709
- amzn-201803
- amzn2-20181024
- centos-7
- debian-8-7
- debian-9-3
- rhel-7-3
- ubuntu-1404
- ubuntu-1604
- ubuntu-1804
