### PR TITLE
Fix when conditional in config task

### DIFF
--- a/tasks/cloudsight_setup.yml
+++ b/tasks/cloudsight_setup.yml
@@ -33,8 +33,8 @@
     group: root
     mode: 0644
   when:
-    - threatstack_agent_config_args is undefined
-    - agent_type is undefined
+    - threatstack_agent_config_args is defined
+    - agent_type is defined
   register: config_args
 
 - name: Configure extra cloudsight parameters


### PR DESCRIPTION
The task that adds config args is skipped when there ARE config args. 
Reversing the polarity of the conditional to execute the task when there's args to add