### PR TITLE
Ensuring the agent is stopped before running setup

### DIFF
--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -37,10 +37,17 @@
   register: config_file
   when: threatstack_agent_config_args != None
 
+- name: Ensure ThreatStack is stopped
+  service:
+    name: threatstack
+    state: stopped
+  when: setup_file.changed or config_file.changed
+
 - name: Agent setup
   command: "{{ setup_string }}"
   register: setup_result
   changed_when: False
+  when: setup_file.changed
 
 - name: Wait 5 seconds
   pause:


### PR DESCRIPTION
When the agent isn't stopped before running the setup command a conflict could exist causing the playbook to fail midway.