### PR TITLE
Harden tsagent setup task.

### DIFF
--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -12,7 +12,10 @@
 
 - name: Get agent registration status
   command: tsagent info
+  check_mode: no
   register: tsagent_info_cmd
+  changed_when: False
+  
 
 - name: Create file to track checksum of setup string
   copy:
@@ -47,6 +50,8 @@
     state: stopped
   when: setup_file.changed or config_file.changed
 
+- debug: var=tsagent_info_cmd
+
 - name: Agent setup
   command: "{{ setup_string }}"
   register: setup_result
@@ -54,7 +59,7 @@
   until: setup_result is succeeded
   retries: 3
   delay: 10
-  when: setup_file.changed or (tsagent_info_cmd.stdout.find('You must register your agent') != -1)
+  when: (setup_file.changed) or (tsagent_info_cmd.stdout.find('You must register your agent') != -1)
 
 - name: Wait 5 seconds
   pause:
@@ -73,12 +78,13 @@
     seconds: 5
   when: setup_file.changed or config_file.changed
 
-- name: Test agent state
+- name: Get agent state
   command: tsagent status
   register: tsagent_status
   retries: 5
   delay: 2
-  until: tsagent_status.rc == 0
+  until: tsagent_status is succeeded
+  changed_when: False
   when: setup_file.changed or config_file.changed
   tags:
     - checkstate

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -12,10 +12,9 @@
 
 - name: Get agent registration status
   command: tsagent info
-  check_mode: no
+  check_mode: no # Cannot skip this step in check mode.
   register: tsagent_info_cmd
-  changed_when: False
-  
+  changed_when: False  # Info only so shouldn't be captured as a change.
 
 - name: Create file to track checksum of setup string
   copy:
@@ -50,8 +49,6 @@
     state: stopped
   when: setup_file.changed or config_file.changed
 
-- debug: var=tsagent_info_cmd
-
 - name: Agent setup
   command: "{{ setup_string }}"
   register: setup_result
@@ -59,6 +56,8 @@
   until: setup_result is succeeded
   retries: 3
   delay: 10
+  # We want to run setup if the setup configuration has changed, or if we detect the agent has
+  # not completed registration (e.g., a prior, failed ansible run).
   when: (setup_file.changed) or (tsagent_info_cmd.stdout.find('You must register your agent') != -1)
 
 - name: Wait 5 seconds

--- a/tasks/tsagent_setup.yml
+++ b/tasks/tsagent_setup.yml
@@ -10,6 +10,10 @@
   set_fact:
     setup_checksum: "{{ setup_string | checksum }}"
 
+- name: Get agent registration status
+  command: tsagent info
+  register: tsagent_info_cmd
+
 - name: Create file to track checksum of setup string
   copy:
     content: "{{ setup_checksum }}"
@@ -47,7 +51,10 @@
   command: "{{ setup_string }}"
   register: setup_result
   changed_when: False
-  when: setup_file.changed
+  until: setup_result is succeeded
+  retries: 3
+  delay: 10
+  when: setup_file.changed or (tsagent_info_cmd.stdout.find('You must register your agent') != -1)
 
 - name: Wait 5 seconds
   pause:


### PR DESCRIPTION
Doing this in two ways:
1. Retry if a failure is detected.
2. Ensure we re-run tsagent setup if the agent has not been registered.

The second case is important for re-running ansible if previous failures leave the agent in a bad state.