### PR TITLE
don't require threatstack_feature_plan if threatstack_configure_agent is false

### DIFF
--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -12,4 +12,5 @@
     msg: "threatstack_feature_plan is mandatory for 1.x agents!"
   when:
     - threatstack_v1
+    - threatstack_configure_agent
     - agent_type == ''


### PR DESCRIPTION
the playbook fails when installing a v1 agent with `threatstack_configure_agent` set to `false` if `threatstack_feature_plan` is not set:

```
TASK [threatstack.threatstack-ansible : Ensure agent_type is defined] *******************************************************************************************************************************************************************************
Tuesday 22 October 2019  15:55:10 -0700 (0:00:00.058)       0:01:33.603 ******* 
fatal: [10.10.1.186]: FAILED! => changed=false 
  msg: threatstack_feature_plan is mandatory for 1.x agents!
```

the install does not use use the `threatstack_feature_plan` or `agent_type` facts, so it doesn't seem like setting it should be required