### PR TITLE
Functionality to pin a specific version of the threatstack agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ threatstack_pkg_state: present
 threatstack_pkg_validate: yes
 # to set a version of the agent use threatstack-agent=X.Y.Z (Debian) or threatstack-agent-X.Y.Z (RedHat)
 threatstack_pkg: threatstack-agent
+threatstack_pkg_version:
 threatstack_ruleset:
   - 'Base Rule Set'
 threatstack_config_dir: '/etc/threatstack'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ threatstack_pkg_state: present
 threatstack_pkg_validate: yes
 # to set a version of the agent use threatstack-agent=X.Y.Z (Debian) or threatstack-agent-X.Y.Z (RedHat)
 threatstack_pkg: threatstack-agent
-threatstack_pkg_version:
 threatstack_ruleset:
   - 'Base Rule Set'
 threatstack_config_dir: '/etc/threatstack'

--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -31,10 +31,10 @@
   apt:
     name: "{{ threatstack_pkg }}"
     state: "{{ threatstack_pkg_state }}"
-  when: threatstack_pkg is not defined
+  when: threatstack_pkg_version is not defined
 
 - name: Ensure ThreatStack specified version is installed
   apt:
     name: "{{ threatstack_pkg }}={{threatstack_pkg_version}}"
     state: "{{ threatstack_pkg_state }}"
-  when: threatstack_pkg is defined
+  when: threatstack_pkg_version is defined

--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -14,21 +14,11 @@
     id: 6EE04BD4
     validate_certs: "{{ threatstack_pkg_validate | bool }}"
 
-- name: Add Ubuntu ThreatStack apt repository
+- name: Add ThreatStack apt repository
   apt_repository:
     repo: "deb {{ threatstack_pkg_url }}/Ubuntu {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
-  when:
-    - when dry_run is undefined
-
-- name: Add Ubuntu ThreatStack apt repository dry run
-  apt_repository:
-    repo: "deb {{ threatstack_pkg_url }} {{ ansible_distribution_release }} {{package_branch}}"
-    state: present
-    update_cache: yes
-  when:
-    - when dry_run is defined
 
 - name: Ensure 2.x is installed when no version specified
   set_fact:
@@ -37,6 +27,14 @@
     - not threatstack_v1
     - threatstack_pkg == 'threatstack-agent'
 
-- name: Ensure ThreatStack latest is installed
+- name: Ensure ThreatStack is installed
   apt:
     name: "{{ threatstack_pkg }}"
+    state: "{{ threatstack_pkg_state }}"
+  when: threatstack_pkg is not defined
+
+- name: Ensure ThreatStack specified version is installed
+  apt:
+    name: "{{ threatstack_pkg }}={{threatstack_pkg_version}}"
+    state: "{{ threatstack_pkg_state }}"
+  when: threatstack_pkg is defined

--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -14,11 +14,21 @@
     id: 6EE04BD4
     validate_certs: "{{ threatstack_pkg_validate | bool }}"
 
-- name: Add ThreatStack apt repository
+- name: Add Ubuntu ThreatStack apt repository
   apt_repository:
     repo: "deb {{ threatstack_pkg_url }}/Ubuntu {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
+  when:
+    - when dry_run is undefined
+
+- name: Add Ubuntu ThreatStack apt repository dry run
+  apt_repository:
+    repo: "deb {{ threatstack_pkg_url }} {{ ansible_distribution_release }} {{package_branch}}"
+    state: present
+    update_cache: yes
+  when:
+    - when dry_run is defined
 
 - name: Ensure 2.x is installed when no version specified
   set_fact:
@@ -27,7 +37,6 @@
     - not threatstack_v1
     - threatstack_pkg == 'threatstack-agent'
 
-- name: Ensure ThreatStack is installed
+- name: Ensure ThreatStack latest is installed
   apt:
     name: "{{ threatstack_pkg }}"
-    state: "{{ threatstack_pkg_state }}"

--- a/tasks/yum_install.yml
+++ b/tasks/yum_install.yml
@@ -25,3 +25,11 @@
     name: "{{ threatstack_pkg }}"
     state: "{{ threatstack_pkg_state }}"
     update_cache: yes
+  when: threatstack_pkg is not defined
+
+- name: Ensure Agent specified version is installed
+  yum:
+    name: "{{ threatstack_pkg }}-{{threatstack_pkg_version}}"
+    state: "{{ threatstack_pkg_state }}"
+    update_cache: yes
+  when: threatstack_pkg_version is defined


### PR DESCRIPTION
Ansible adds an attribute that allows yum and apt module to pin a specific version of the threatstack agent