### PR TITLE
Fix threatstack user homedir to comply with CIS benchmark guidelines

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,20 @@
   include: yum_install.yml
   when: ansible_os_family == 'RedHat'
 
+- name: Get threatstack user info
+  getent:
+    database: passwd
+    key: threatstack
+- debug:
+    var: getent_passwd
+
+- name: Ensure threatstack user homedirectory is owned by user and mode 0750
+  file:
+    path: "{{ getent_passwd['threatstack'][4] }}"
+    mode: '0750'
+    owner: threatstack
+    group: threatstack
+
 - name: agent setup
   include: tsagent_setup.yml
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,8 +21,6 @@
   getent:
     database: passwd
     key: threatstack
-- debug:
-    var: getent_passwd
 
 - name: Ensure threatstack user homedirectory is owned by user and mode 0750
   file:

--- a/test/integration/custom/serverspec/default_spec.rb
+++ b/test/integration/custom/serverspec/default_spec.rb
@@ -14,3 +14,11 @@ end
 describe command('tsagent config --list') do
   its(:stdout) { should match /log.maxSize=22/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
 end
+
+describe file('/opt/threatstack') do
+  it { should_not be_more_permissive_than('0750') }
+end
+
+describe file('/opt/threatstack') do
+  its('owner') { should eq user.user }
+end``

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -15,3 +15,11 @@ describe command('tsagent status') do
   # Sometimes due to other services, like auditd, the install would be successful, but then this service would get killed
   its(:stdout) { should match /UP Threat Stack Audit Collection/ } # rubocop: disable Lint/AmbiguousRegexpLiteral
 end
+
+describe file('/opt/threatstack') do
+  it { should_not be_more_permissive_than('0750') }
+end
+
+describe file('/opt/threatstack') do
+  its('owner') { should eq user.user }
+end


### PR DESCRIPTION
added tasks to ensure the threatstack user homedirectory is owned by that user, and is mode 0750, per CIS hardening guidelines

I have tested this against Ubuntu 18.04. I'm having trouble figuring out how to run the test-kitchen tests. I haven't done much with test-kitchen, so if you can provide any further instructions on how to do it, I can run the tests.

Or, if there is CI to run the tests, I'm happy to rely on those results.