### PR TITLE
Do not report change for idempotent task

### DIFF
--- a/tasks/disable_auditd.yml
+++ b/tasks/disable_auditd.yml
@@ -3,6 +3,7 @@
   command: service auditd status
   register: auditd_status
   ignore_errors: true
+  changed_when: false
   args:
     warn: no
 


### PR DESCRIPTION
This task just checks current status, but it causes Ansible to report
change on every run even when nothing really changed. Adding
`changed_when` prevents this somewhat confusing output.