### PR TITLE
Several fixes.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,13 +28,13 @@ provisioner:
 # Set this to work around issues with kitchen-ansible erroring out: https://github.com/neillturner/kitchen-ansible/issues/295
 # If you set the `max_ssh_sessions` too high, test-kitchen will crash
 transport:
-  name: ssh
-  max_ssh_sessions: 4
+  name: docker
 
 platforms:
   - name: amazon-1
     driver_config:
       image: amazonlinux:1
+      docker_platform: linux/amd64
       platform: amazonlinux
       run_command: /sbin/init
       privileged: true
@@ -49,6 +49,7 @@ platforms:
   - name: amazon-2
     driver_config:
       image: amazonlinux:2
+      docker_platform: linux/amd64
       platform: amazonlinux
       run_command: /sbin/init
       privileged: true
@@ -63,6 +64,7 @@ platforms:
   - name: centos-7
     driver_config:
       image: centos:7
+      docker_platform: linux/amd64
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -75,7 +77,8 @@ platforms:
         - systemctl enable auditd.service
   - name: centos-8
     driver_config:
-      image: centos:8
+      image: quay.io/centos/centos:stream8
+      docker_platform: linux/amd64
       run_command: /sbin/init
       privileged: true
       run_options:
@@ -89,6 +92,7 @@ platforms:
   - name: debian-8
     driver_config:
       image: debian:8
+      docker_platform: linux/amd64
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -125,9 +129,9 @@ platforms:
       provision_command:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
-  - name: ubuntu-16.04
+  - name: debian-11
     driver_config:
-      image: ubuntu:16.04
+      image: debian:11
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -138,9 +142,25 @@ platforms:
       provision_command:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
+  - name: ubuntu-16.04
+    driver_config:
+      image: ubuntu:16.04
+      docker_platform: linux/amd64
+      run_command: /sbin/init
+      cap_add:
+        - SYS_ADMIN
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - apt install -y wget
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable ssh.service
   - name: ubuntu-18.04
     driver_config:
       image: ubuntu:18.04
+      docker_platform: linux/amd64
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -156,6 +176,7 @@ platforms:
     #   extra_vars:
     driver_config:
       image: ubuntu:20.04
+      docker_platform: linux/amd64
       run_command: /sbin/init
       cap_add:
         - SYS_ADMIN
@@ -166,7 +187,22 @@ platforms:
       provision_command:
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - systemctl enable ssh.service
-
+  - name: ubuntu-22.04
+    # provisioner:
+    #   extra_vars:
+    driver_config:
+      image: ubuntu:20.04
+      docker_platform: linux/amd64
+      run_command: /sbin/init
+      cap_add:
+        - SYS_ADMIN
+      run_options:
+        env: container=docker
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+      provision_command:
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - systemctl enable ssh.service
 suites:
   - name: default
   - name: custom

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :system_tests do
   gem 'test-kitchen',       :require => false
   gem 'kitchen-docker',     :require => false
   gem 'kitchen-ansible',    :require => false
+  gem 'kitchen-inspec',     :require => false
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ threatstack_pkg_state: present
 threatstack_pkg_validate: yes
 # to set a version of the agent use threatstack-agent=X.Y.Z (Debian) or threatstack-agent-X.Y.Z (RedHat)
 threatstack_pkg: threatstack-agent
+threatstack_pkg_allow_downgrades: no
 threatstack_ruleset:
   - 'Base Rule Set'
 threatstack_hostname:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - 8
     - 9
     - 10
+    - 11
   - name: Amazon
     versions:
     - all
@@ -29,6 +30,7 @@ galaxy_info:
     - xenial
     - bionic
     - focal
+    - jammy
   categories:
   - cloud
   - cloud:ec2

--- a/tasks/apt_install.yml
+++ b/tasks/apt_install.yml
@@ -1,5 +1,26 @@
 ---
-- name: apt -- Ensure agent dependencies are installed
+# MIT License
+#
+# Copyright (c) 2015-2022 F5, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+- name: apt -- Ensure agent dependencies are installed distributions with python2 as the default
   apt:
     name: "{{ packages }}"
     state: present
@@ -7,6 +28,22 @@
     packages:
       - python-apt
       - apt-transport-https
+  when:
+    - (ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('22.04', '<'))
+    - (ansible_distribution != 'Debian' or ansible_distribution_version is version('11', '<'))
+
+# For Ubuntu 22.04+ and Debian 11+, python 3 is default, so need different packages
+- name: apt -- Ensure Ubuntu 22.04+ compatible dependencies are installed
+  include_tasks: python3_apt.yml
+  when:
+  - ansible_distribution == 'Ubuntu'
+  - ansible_distribution_version is version('22.04', '>=')
+
+- name: apt -- Ensure Debian 11+ compatible dependencies are installed
+  include_tasks: python3_apt.yml
+  when:
+    - ansible_distribution == 'Debian'
+    - ansible_distribution_version is version('11', '>=')
 
 - name: apt -- Add agent repository key
   apt_key:
@@ -22,7 +59,7 @@
 
 - name: apt -- Ensure latest agent is installed when no version specified
   set_fact:
-    threatstack_pkg: threatstack-agent=2*
+    threatstack_pkg: threatstack-agent=3*
   when:
     - threatstack_pkg == 'threatstack-agent'
 
@@ -30,6 +67,7 @@
   apt:
     name: "{{ threatstack_pkg }}"
     state: "{{ threatstack_pkg_state }}"
+    dpkg_options: "force-confold,force-confdef{{ ',force-downgrade' if threatstack_pkg_allow_downgrades else '' }}"
   when: threatstack_pkg_version is not defined
 
 - name: apt -- Ensure agent specified version is installed

--- a/tasks/python3_apt.yml
+++ b/tasks/python3_apt.yml
@@ -1,0 +1,30 @@
+---
+# MIT License
+#
+# Copyright (c) 2015-2022 F5, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+- name: apt -- Install dependencies for distributions with python3 as the default
+  apt:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - python3-apt
+      - apt-transport-https

--- a/tasks/yum_install.yml
+++ b/tasks/yum_install.yml
@@ -15,7 +15,7 @@
 
 - name: yum -- Ensure latest agent is installed when no version specified
   set_fact:
-    threatstack_pkg: threatstack-agent-2*
+    threatstack_pkg: threatstack-agent-3*
   when:
     - threatstack_pkg == 'threatstack-agent'
 
@@ -31,6 +31,7 @@
     name: "{{ threatstack_pkg }}-{{threatstack_pkg_version}}"
     state: "{{ threatstack_pkg_state }}"
     update_cache: yes
+    allow_downgrade: "{{ threatstack_pkg_allow_downgrades | bool }}"
   when: threatstack_pkg_version is defined
 
 - name: yum -- Stop and disable agent if not to be configured


### PR DESCRIPTION
* Default to latest agent 3.X if no version specified
* Allow downgrades as an option (defaults to off)
* Handle dependencies installation when new distributions have python3 as the default system python
* Test framework updates