### PR TITLE
Remove warn argument from disable_auditd.yml

### DIFF
--- a/tasks/disable_auditd.yml
+++ b/tasks/disable_auditd.yml
@@ -4,19 +4,13 @@
   register: auditd_status
   ignore_errors: true
   changed_when: false
-  args:
-    warn: no
 
 - name: Stop service auditd
   command: service auditd stop
   when: auditd_status.rc == 0
   ignore_errors: "{{ ansible_check_mode }}"
-  args:
-    warn: no
 
 - name: Disable service auditd
   command: systemctl disable auditd
   when: auditd_status.rc == 0
   ignore_errors: "{{ ansible_check_mode }}"
-  args:
-    warn: no


### PR DESCRIPTION
This PR removes the references to `args.warn` in `disable_auditd.yml`. As discussed in [this stackoverflow](https://stackoverflow.com/questions/74544930/ansible-unsupported-parameters-for-ansible-legacy-command-module-warn), the warn parameter for shell was deprecated in Ansible 2.11 and removed in Ansible 2.14. 

When run with Ansible `>= 2.14`, the playbook currently errors out with the following message:
```
fatal: [default]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends."}
```

After applying this patch, the playbook executes without error on Ubuntu 20.04 and Amazon Linux 2 with Ansible `2.14.9`.